### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -355,7 +355,7 @@ impl<'a> Compiler<'a> {
 					inf_write!(into, "{n}.0");
 				}
 				else {
-					inf_write!(into, "{:.}", n);
+					inf_write!(into, "{}", n);
 				}
 			},
 			(Ty::Bool, Val::Literal(LoxValue::Bool(n))) => {
@@ -534,7 +534,7 @@ impl<'a> Compiler<'a> {
 						inf_write!(into, "jay_box_number({}.0)", value);
 					}
 					else {
-						inf_write!(into, "jay_box_number({:.})", value)
+						inf_write!(into, "jay_box_number({})", value)
 					}
 				}
 			}


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.